### PR TITLE
update to zig 0.14.0-dev.1495+f29bdd674

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = "structopt",
     .version = "0.0.0",
+    .minimum_zig_version = "0.14.0-dev.1495+f29bdd674",
     .dependencies = .{},
     .paths = .{
         "build.zig",


### PR DESCRIPTION
After these changes `zig build test` passes with the noted zig version. Also, populated the `minimum_zig_version` metadata field in build.zig.zon.