### PR TITLE
fix type coercion failure

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -221,7 +221,7 @@ pub const Command = struct {
         }
 
         // Parse the named arguments
-        var peeked = while (iter.*.next()) |arg_str| {
+        var peeked: ?[]const u8 = while (iter.*.next()) |arg_str| {
             // Stop parsing if we find a positional argument
             if (arg_str[0] != '-') {
                 break arg_str;


### PR DESCRIPTION
fixes `error: expected type '*?[]const u8', found '*?[:0]const u8'` when calling parseValue